### PR TITLE
Add resources ui file for corrent running in linux

### DIFF
--- a/QuickSegment/CMakeLists.txt
+++ b/QuickSegment/CMakeLists.txt
@@ -8,6 +8,7 @@ set(MODULE_PYTHON_SCRIPTS
 
 set(MODULE_PYTHON_RESOURCES
   Resources/Icons/${MODULE_NAME}.png
+  Resources/UI/${MODULE_NAME}.ui
   )
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Without it GUI doesn't show module widgets in linux.

Do you have the same example or something similar but in C++?